### PR TITLE
D3QN / RDQN: Do not enable memory growth with no GPU

### DIFF
--- a/l2rpn_baselines/DoubleDuelingDQN/evaluate.py
+++ b/l2rpn_baselines/DoubleDuelingDQN/evaluate.py
@@ -72,7 +72,8 @@ def evaluate(env,
     
     # Limit gpu usage
     physical_devices = tf.config.list_physical_devices('GPU')
-    tf.config.experimental.set_memory_growth(physical_devices[0], True)
+    if len(physical_devices):
+        tf.config.experimental.set_memory_growth(physical_devices[0], True)
 
     runner_params = env.get_params_for_runner()
     runner_params["verbose"] = verbose

--- a/l2rpn_baselines/DoubleDuelingRDQN/evaluate.py
+++ b/l2rpn_baselines/DoubleDuelingRDQN/evaluate.py
@@ -63,7 +63,8 @@ def evaluate(env,
 
     # Limit gpu usage
     physical_devices = tf.config.list_physical_devices('GPU')
-    tf.config.experimental.set_memory_growth(physical_devices[0], True)
+    if len(physical_devices):
+        tf.config.experimental.set_memory_growth(physical_devices[0], True)
 
     runner_params = env.get_params_for_runner()
     runner_params["verbose"] = verbose


### PR DESCRIPTION
The D3QN and RDQN baselines attempt to enable memory growth even when no GPU is available (`len(physical_devices) < 1`). Most of the other baselines check this condition before enabling memory growth to allow CPU only evaluation, so I have done the same here.