### PR TITLE
Update default value for observation and action normalization

### DIFF
--- a/l2rpn_baselines/PPO_SB3/evaluate.py
+++ b/l2rpn_baselines/PPO_SB3/evaluate.py
@@ -27,8 +27,8 @@ def evaluate(env,
              save_gif=False,
              gymenv_class=GymEnv,
              gymenv_kwargs=None,
-             obs_space_kwargs=None,  # TODO
-             act_space_kwargs=None,  # TODO
+             obs_space_kwargs={},
+             act_space_kwargs={},
              iter_num=None,
              **kwargs):
     """

--- a/l2rpn_baselines/PPO_SB3/evaluate.py
+++ b/l2rpn_baselines/PPO_SB3/evaluate.py
@@ -27,8 +27,8 @@ def evaluate(env,
              save_gif=False,
              gymenv_class=GymEnv,
              gymenv_kwargs=None,
-             obs_space_kwargs={},
-             act_space_kwargs={},
+             obs_space_kwargs=None,
+             act_space_kwargs=None,
              iter_num=None,
              **kwargs):
     """
@@ -149,6 +149,11 @@ def evaluate(env,
             env.close()
 
     """
+    
+    if obs_space_kwargs is None:
+        obs_space_kwargs = {}
+    if act_space_kwargs is None:
+        act_space_kwargs = {}
 
     # load the attributes kept
     my_path = os.path.join(load_path, name)


### PR DESCRIPTION
An error occurs when using `None` as default value for obs_space_kwargs and act_space_kwargs:
```python
g2op_agent, res = ppo_evaluate(env, load_path="path/to/agent/", name="PPO_SB3", nb_episode=10)
```
Output:
```
TypeError: grid2op.gym_compat.box_gym_obsspace.BoxGymObsSpace() argument after ** must be a mapping, not NoneType
```

If we set the default value for obs_space_kwargs and act_space_kwargs to an empty dictionary we avoid this error:
```python
g2op_agent, res = ppo_evaluate(
                            env,
                            load_path="test/",
                            name="PPO_SB3",
                            nb_episode=15,
                            obs_space_kwargs={},
                            act_space_kwargs={}
                          )
```
Output:
```
```