### PR TITLE
Fix a bug in OptimCVXPY

### DIFF
--- a/l2rpn_baselines/OptimCVXPY/optimCVXPY.py
+++ b/l2rpn_baselines/OptimCVXPY/optimCVXPY.py
@@ -537,8 +537,6 @@ class OptimCVXPY(BaseAgent):
         index_disc = obs.v_or == 0.
         self._th_lim_mw.value[index_disc] = 0.001 * (obs.thermal_limit * self._v_ref )[index_disc] * np.sqrt(3.)
         
-        # TODO what if (0.001 * obs.thermal_limit)**2 * obs.v_or **2 * 3. - obs.q_or**2 is negative !
-        
     def _update_storage_power_obs(self, obs: BaseObservation):
         self._storage_power_obs.value += obs.storage_power.sum()
         

--- a/l2rpn_baselines/OptimCVXPY/optimCVXPY.py
+++ b/l2rpn_baselines/OptimCVXPY/optimCVXPY.py
@@ -525,9 +525,13 @@ class OptimCVXPY(BaseAgent):
             self.bus_storage.value[:] = tmp_
         
     def _update_th_lim_param(self, obs: BaseObservation):
+        threshold_ = 1.
         # take into account reactive value (and current voltage) in thermal limit
         self._th_lim_mw.value[:] =  (0.001 * obs.thermal_limit)**2 * obs.v_or **2 * 3. - obs.q_or**2
-        self._th_lim_mw.value[:] = np.sqrt(self._th_lim_mw.value)
+        # if (0.001 * obs.thermal_limit)**2 * obs.v_or **2 * 3. - obs.q_or**2 is too small, I put 1
+        mask_ok = self._th_lim_mw.value >= threshold_
+        self._th_lim_mw.value[mask_ok] = np.sqrt(self._th_lim_mw.value[mask_ok])
+        self._th_lim_mw.value[~mask_ok] = threshold_ 
         
         # do whatever you can for disconnected lines
         index_disc = obs.v_or == 0.


### PR DESCRIPTION
When using OptimCVXPY, we sometimes obtained the following bug:
```
l2rpn_baselines/OptimCVXPY/optimCVXPY.py:526: RuntimeWarning: invalid value encountered in sqrt
  self._th_lim_mw.value[:] = np.sqrt(self._th_lim_mw.value)
```
The modification puts 1 in the sqrt function if the value inside is too small (<=1). We chose 1 because sqrt(1)=1, consequently the transition remains smooth.