### PR TITLE
Remove a deepcopy on a dict containing a GymEnv to avoid an error

### DIFF
--- a/l2rpn_baselines/utils/gymAgent.py
+++ b/l2rpn_baselines/utils/gymAgent.py
@@ -103,7 +103,7 @@ class GymAgent(BaseAgent):
             self._nn_path = None
             
         if nn_kwargs is not None:
-            self._nn_kwargs = copy.deepcopy(nn_kwargs)
+            self._nn_kwargs = nn_kwargs
         else:
             self._nn_kwargs = None
         


### PR DESCRIPTION
Hello,
This PR intends to bypass the issue Grid2op/grid2op#672.
With more recent versions of the common libraries, copying a `GymEnv` object returns the following error: `*** AttributeError: 'NoneType' object has no attribute 'copy'`. It is a problem when you initialize a `SB3Agent` agent.
In the issue, I had suggested a method for copying a `GymEnv` object, but in the end you advised me to simply avoid copying the environment. I implemented this modification in this PR.
